### PR TITLE
Revert "相談件数の表示"

### DIFF
--- a/components/cards/ConsultationDeskReportsNumberCard.vue
+++ b/components/cards/ConsultationDeskReportsNumberCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <time-bar-chart
-      :title="$t('新型コロナウイルス感染症に関する相談件数')"
+      :title="$t('新型コロナ受診相談窓口相談件数')"
       :title-id="'number-of-reports-to-covid19-consultation-desk'"
       :chart-id="'time-bar-chart-querents'"
       :chart-data="querentsGraph"
@@ -16,37 +16,37 @@
 <i18n>
 {
   "ja": {
-    "新型コロナウイルス感染症に関する相談件数": "新型コロナウイルス感染症に関する相談件数",
+    "新型コロナ受診相談窓口相談件数": "新型コロナ受診相談窓口相談件数",
     "件": {
       "reports": "件"
     }
   },
   "en": {
-    "新型コロナウイルス感染症に関する相談件数": "Number of inquiries to combined telephone advisory center",
+    "新型コロナ受診相談窓口相談件数": "Number of inquiries to combined telephone advisory center",
     "件": {
       "reports": "reports"
     }
   },
   "zh-cn": {
-    "新型コロナウイルス感染症に関する相談件数": "新冠肺炎就诊咨询窗口的咨询数",
+    "新型コロナ受診相談窓口相談件数": "新冠肺炎就诊咨询窗口的咨询数",
     "件": {
       "reports": "件"
     }
   },
   "zh-tw": {
-    "新型コロナウイルス感染症に関する相談件数": "就診窗口諮詢數",
+    "新型コロナ受診相談窓口相談件数": "就診窗口諮詢數",
     "件": {
       "reports": "件"
     }
   },
   "ko": {
-    "新型コロナウイルス感染症に関する相談件数": "코로나19 진찰 상담 창구 상담 건수",
+    "新型コロナ受診相談窓口相談件数": "코로나19 진찰 상담 창구 상담 건수",
     "件": {
       "reports": "건"
     }
   },
   "ja-basic": {
-    "新型コロナウイルス感染症に関する相談件数": "コロナのことで とうきょうと に そうだんした ひとの かず",
+    "新型コロナ受診相談窓口相談件数": "コロナのことで とうきょうと に そうだんした ひとの かず",
     "件": {
       "reports": "けん"
     }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -18,11 +18,11 @@
       <confirmed-cases-details-card />
       <confirmed-cases-number-card />
       <confirmed-cases-attributes-card />
-      <!-- <tested-number-card /> -->
-      <!-- <telephone-advisory-reports-number-card /> -->
+      <!-- <tested-number-card />
+      <telephone-advisory-reports-number-card />
       <consultation-desk-reports-number-card />
-      <!-- <metro-card /> -->
-      <!-- <agency-card /> -->
+      <metro-card />
+      <agency-card /> -->
     </v-row>
   </div>
 </template>
@@ -42,7 +42,7 @@ import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCar
 import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
 // import TestedNumberCard from '@/components/cards/TestedNumberCard.vue'
 // import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvisoryReportsNumberCard.vue'
-import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDeskReportsNumberCard.vue'
+// import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDeskReportsNumberCard.vue'
 // import MetroCard from '@/components/cards/MetroCard.vue'
 // import AgencyCard from '@/components/cards/AgencyCard.vue'
 
@@ -53,10 +53,10 @@ export default {
     StaticInfo,
     ConfirmedCasesDetailsCard,
     ConfirmedCasesNumberCard,
-    ConfirmedCasesAttributesCard,
+    ConfirmedCasesAttributesCard
     // TestedNumberCard,
     // TelephoneAdvisoryReportsNumberCard,
-    ConsultationDeskReportsNumberCard
+    // ConsultationDeskReportsNumberCard,
     // MetroCard,
     // AgencyCard
   },


### PR DESCRIPTION
Reverts hisayan/covid19#9
長野県のみのデータをつくるか、全国の件数であることを明記してからリリースしたほうが良いと思いましたので、いったん Revert します。