### PR TITLE
「最新のお知らせ」をscrollableに

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -64,6 +64,8 @@ export default {
   @include card-container();
   padding: 10px;
   margin-bottom: 20px;
+  height: 18em;
+  overflow: auto;
 }
 
 .WhatsNew-heading {


### PR DESCRIPTION
WhatsNew_add_scrollable

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #25 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 最新のお知らせ（WhatsNew）の高さを固定、スクロールバーを表示

## 📸 スクリーンショット / Screenshots
PC
![whatsnew_pc](https://user-images.githubusercontent.com/1654374/77840107-77736e80-71be-11ea-9e58-e838e74c72e8.png)
Mobile
![whatsnew_iphone5](https://user-images.githubusercontent.com/1654374/77840114-86f2b780-71be-11ea-83e2-35d49f37681c.png)

お疲れ様です！長野県のプロジェクトを見つけ、とてもうれしいです。
よろしければレビューいただけますと幸いです。GitHub初心者のため、不具合などを引き起こしていたら申し訳ありません。お気軽にコメントいただければありがたいです。
上に書いた通り#25 の対応です。
2020年3月29日現在の長野県内は、「検査状況」などの推移が激しくないため、ファーストビューに比較的多くの「最新のおしらせ」が表示でき、かつ、スクロールですべてが参照できるような高さに設定しました。
よろしくお願いします。
