### PR TITLE
2020/03/31リリース用

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -142,6 +142,7 @@ export default {
                 fontSize: 9,
                 fontColor: '#808080',
                 maxTicksLimit: 10,
+                stepSize: 1,
                 callback(label) {
                   return `${label}${self.unit}`
                 }

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -16,7 +16,7 @@
       </div>
       <div class="DataView-Footer">
         <div class="Footer-Left">
-          <!-- <div>
+          <div>
             <a
               v-if="url"
               class="OpenDataLink"
@@ -29,7 +29,7 @@
                 mdi-open-in-new
               </v-icon>
             </a>
-          </div> -->
+          </div>
           <div>
             <a class="Permalink" :href="permalink()">
               <time :datetime="formattedDate">

--- a/components/StaticInfo.vue
+++ b/components/StaticInfo.vue
@@ -6,6 +6,13 @@
     class="StaticInfo"
   >
     <span>{{ text }}</span>
+    <v-icon
+      v-if="!isInternalLink(url)"
+      class="StaticInfo-item-ExternalLinkIcon"
+      size="12"
+    >
+      mdi-open-in-new
+    </v-icon>
     <div v-if="btnText" class="StaticInfo-Button">
       <span>
         {{ btnText }}
@@ -54,6 +61,12 @@ export default class StaticInfo extends Vue {
     }
     @include lessThan($small) {
       margin-top: 4px;
+    }
+  }
+  &-item {
+    &-ExternalLinkIcon {
+      margin-left: 2px;
+      color: $gray-3 !important;
     }
   }
 }

--- a/components/StaticInfo.vue
+++ b/components/StaticInfo.vue
@@ -5,14 +5,16 @@
     :href="isInternalLink(url) ? '' : url"
     class="StaticInfo"
   >
-    <span>{{ text }}</span>
-    <v-icon
-      v-if="!isInternalLink(url)"
-      class="StaticInfo-item-ExternalLinkIcon"
-      size="12"
-    >
-      mdi-open-in-new
-    </v-icon>
+    <span>
+      {{ text }}
+      <v-icon
+        v-if="!isInternalLink(url)"
+        class="StaticInfo-item-ExternalLinkIcon"
+        size="12"
+      >
+        mdi-open-in-new
+      </v-icon>
+    </span>
     <div v-if="btnText" class="StaticInfo-Button">
       <span>
         {{ btnText }}

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -234,6 +234,7 @@ export default {
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
+                stepSize: 1,
                 fontColor: '#808080',
                 suggestedMax: scaledTicksYAxisMax
               }

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -28,6 +28,8 @@ import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 
+import { single as color } from '@/utils/colors'
+
 export default {
   components: { DataView, DataSelector, DataViewBasicInfoPanel },
   props: {
@@ -117,7 +119,7 @@ export default {
               data: this.chartData.map(d => {
                 return d.transition
               }),
-              backgroundColor: '#189b58',
+              backgroundColor: color,
               borderWidth: 0
             }
           ]
@@ -133,7 +135,7 @@ export default {
             data: this.chartData.map(d => {
               return d.cumulative
             }),
-            backgroundColor: '#00B849',
+            backgroundColor: color,
             borderWidth: 0
           }
         ]

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -250,6 +250,7 @@ export default {
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
+                stepSize: 1,
                 fontColor: '#808080'
               }
             }

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -7,7 +7,6 @@
       :chart-option="{}"
       :date="Data.patients.date"
       :info="sumInfoOfPatients"
-      :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
     />
   </v-col>
 </template>

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -7,7 +7,7 @@
       :chart-data="patientsGraph"
       :date="Data.patients.date"
       :unit="$t('人')"
-      :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+      :url="'https://www.pref.nagano.lg.jp/joho/kensei/tokei/johoka/opendata/'"
     />
   </v-col>
 </template>

--- a/data/news.json
+++ b/data/news.json
@@ -1,6 +1,11 @@
 {
     "newsItems": [
       {
+          "date": "2020\/03\/30",
+          "url": "https://www.pref.nagano.lg.jp/hoken-shippei/kenko/kenko/kansensho/joho/bukan-haien.html#seikatsushikin",
+          "text": "「新型コロナウイルス感染症の影響による休業や失業で生活資金にお悩みの皆さまへ」を掲載しました"
+      },
+      {
           "date": "2020\/03\/29",
           "url": "https://www.pref.nagano.lg.jp/hoken-shippei/kenko/kenko/kansensho/joho/bukan-haien.html#onegai0329",
           "text": "「感染拡大地域への往来自粛等に関する県民の皆様へのお願い」を掲載しました"

--- a/utils/colors.ts
+++ b/utils/colors.ts
@@ -1,0 +1,4 @@
+export const single: string = '#006400'
+export const double: string[] = ['#006400', '#1B75BC']
+export const triple: string[] = ['#00441B', '#006400', '#1B75BC']
+export const quadruple: string[] = ['#00441B', '#006400', '#1B75BC', '#505B00']


### PR DESCRIPTION
グラフの縦軸を整数化
データの取得先、リンク追加
相談窓口へのリンクに外部リンクアイコン追加
31日の情報でお知らせを更新
東京都のサイトに合わせて色覚異常者向けの色に変更