### PR TITLE
Feature/sns share

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -56,12 +56,12 @@ const config: Configuration = {
         property: 'og:image',
         content:
           'https://user-images.githubusercontent.com/941125/76682913-4e41d280-6643-11ea-91a4-c2e2b53650fc.png'
-      } // ,
-      // {
-      //   hid: 'twitter:card',
-      //   name: 'twitter:card',
-      //   content: 'summary_large_image'
-      // },
+      },
+      {
+        hid: 'twitter:card',
+        name: 'twitter:card',
+        content: 'summary_large_image'
+      },
       // {
       //   hid: 'twitter:site',
       //   name: 'twitter:site',
@@ -72,16 +72,17 @@ const config: Configuration = {
       //   name: 'twitter:creator',
       //   content: '@tokyo_bousai'
       // },
-      // {
-      //   hid: 'twitter:image',
-      //   name: 'twitter:image',
-      //   content: 'https://stopcovid19.metro.tokyo.lg.jp/ogp.png'
-      // },
-      // {
-      //   hid: 'fb:app_id',
-      //   property: 'fb:app_id',
-      //   content: '2879625188795443'
-      // }
+      {
+        hid: 'twitter:image',
+        name: 'twitter:image',
+        content:
+          'https://user-images.githubusercontent.com/941125/76682913-4e41d280-6643-11ea-91a4-c2e2b53650fc.png'
+      },
+      {
+        hid: 'fb:app_id',
+        property: 'fb:app_id',
+        content: '1160768984265556'
+      }
     ],
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },


### PR DESCRIPTION
#51 対応

SNSにてシェアしたときの設定をしました。
内容は以下の通り

- Twitter Cardになるように、公式に沿って変更
- Facebook APPS_IDを新規に取得し、設定
- OGPの時の画像を設定

なお、手元でビルドの確認はしていますが、OGPの表示をテストできる環境が無し。
マージ後、再確認の必要はあります。