### PR TITLE
「検査陽性者の状況」から"軽症・中等症者"、"重症者"を削除

### DIFF
--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -125,16 +125,8 @@ export default {
       }
     },
     /** グラフ内容がわかる支援技術用テキストの中身を取得する **/
-    ariaLabel(
-      inspected,
-      positive,
-      hospitalized,
-      mild,
-      critically,
-      deceased,
-      discharged
-    ) {
-      const ariaLabel = `検査陽性者の状況: 検査実施人数は${inspected}人、うち累積の陽性者数は${positive}人です。入院中は${hospitalized}人で、うち軽症・中等症は${mild}人、また重症は${critically}人です。さらに死亡は${deceased}人、退院は${discharged}人です。`
+    ariaLabel(inspected, positive, hospitalized, deceased, discharged) {
+      const ariaLabel = `検査陽性者の状況: 検査実施人数は${inspected}人、うち累積の陽性者数は${positive}人です。入院中は${hospitalized}人です。さらに死亡は${deceased}人、退院は${discharged}人です。`
       return ariaLabel
     }
   }

--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -28,7 +28,7 @@
       </div>
       <ul class="group">
         <li class="item in-hospital">
-          <div class="gutter oneThird">
+          <div class="gutter">
             <div class="box">
               <span>{{ $t('入院中') }}</span>
               <span>
@@ -37,32 +37,6 @@
               </span>
             </div>
           </div>
-          <ul class="group">
-            <li class="item mild">
-              <div class="gutter">
-                <div class="box short">
-                  <!-- eslint-disable vue/no-v-html-->
-                  <span v-html="$t('軽症・<br />中等症')" />
-                  <!-- eslint-enable vue/no-v-html-->
-                  <span>
-                    <b>{{ 軽症中等症 }}</b>
-                    <span class="unit">{{ $t('人') }}</span>
-                  </span>
-                </div>
-              </div>
-            </li>
-            <li class="item serious">
-              <div class="gutter">
-                <div class="box short">
-                  <span>{{ $t('重症') }}</span>
-                  <span>
-                    <b>{{ 重症 }}</b>
-                    <span class="unit">{{ $t('人') }}</span>
-                  </span>
-                </div>
-              </div>
-            </li>
-          </ul>
         </li>
         <li class="item deceased">
           <div class="gutter">
@@ -93,15 +67,29 @@
 
 <script>
 export default {
-  props: [
-    '検査実施人数',
-    '陽性物数',
-    '入院中',
-    '軽症中等症',
-    '重症',
-    '死亡',
-    '退院'
-  ],
+  /* eslint-disable vue/prop-name-casing */
+  props: {
+    検査実施人数: {
+      type: Number,
+      required: true
+    },
+    陽性物数: {
+      type: Number,
+      required: true
+    },
+    入院中: {
+      type: Number,
+      required: true
+    },
+    死亡: {
+      type: Number,
+      required: true
+    },
+    退院: {
+      type: Number,
+      required: true
+    }
+  },
   methods: {
     /** 桁数に応じて位置の調整をする */
     getAdjustX(input) {
@@ -155,9 +143,6 @@ export default {
 .gutter {
   width: 100%;
   padding-right: 3px;
-  &.oneThird {
-    width: calc(100% / 3);
-  }
 }
 .box {
   $box-height: 170px;
@@ -193,7 +178,7 @@ export default {
 
 // 検査
 .item.checked {
-  width: calc(100% / 7);
+  width: calc(100% / 5);
   > .gutter > .box {
     border-color: $gray-1;
     color: $gray-1;
@@ -203,40 +188,27 @@ export default {
 .item.positive {
   display: flex;
   justify-content: space-between;
-  width: calc(100% / 7 * 6);
+  width: calc(100% / 5 * 4);
   > .group {
-    width: calc(100% / 6 * 5);
+    width: calc(100% / 4 * 3);
   }
 }
 // 入院
 .item.in-hospital {
   display: flex;
   justify-content: space-between;
-  width: calc(100% / 5 * 3);
-  > .group {
-    width: calc(100% / 3 * 2);
-  }
-}
-// 軽症・中等症
-.item.mild {
-  width: calc(100% / 2);
-}
-// 重症
-.item.serious {
-  width: calc(100% / 2);
+  width: calc(100% / 3);
 }
 // 死亡
 .item.deceased {
-  width: calc(100% / 5);
+  width: calc(100% / 3);
 }
 // 退院
 .item.recovered {
-  width: calc(100% / 5);
+  width: calc(100% / 3);
 }
 
 .item.positive > .gutter > .box::before,
-.item.in-hospital > .gutter > .box::before,
-.item.serious > .gutter > .box::before,
 .item.recovered > .gutter > .box::before {
   content: '';
   display: block;
@@ -254,17 +226,13 @@ export default {
   border-left: none;
   border-right: none;
 }
-.item.serious > .gutter > .box::before,
 .item.recovered > .gutter > .box::before {
   top: calc(-35px - 3px);
   right: -3px;
   border-left: none;
 }
-.item.serious > .gutter > .box::before {
-  width: 200%;
-}
 .item.recovered > .gutter > .box::before {
-  width: 520%;
+  width: 320%;
 }
 
 @function px2vw($px, $vw) {
@@ -294,7 +262,6 @@ export default {
   }
   .item.positive > .gutter > .box::before,
   .item.in-hospital > .gutter > .box::before,
-  .item.serious > .gutter > .box::before,
   .item.recovered > .gutter > .box::before {
     border-width: px2vw($bdw, $vw);
     height: px2vw($boxdiff - $bdw, $vw);
@@ -305,7 +272,6 @@ export default {
     right: calc(-100% - #{px2vw($bdw * 2, $vw)} + 0.3px);
     width: calc(100% + #{px2vw($bdw * 2, $vw)});
   }
-  .item.serious > .gutter > .box::before,
   .item.recovered > .gutter > .box::before {
     top: px2vw(-$boxdiff - $bdw, $vw);
     right: px2vw(-$bdw, $vw);

--- a/utils/formatConfirmedCases.ts
+++ b/utils/formatConfirmedCases.ts
@@ -9,16 +9,6 @@ type DataType = {
         {
           attr: '入院中'
           value: number
-          children: [
-            {
-              attr: '軽症・中等症'
-              value: number
-            },
-            {
-              attr: '重症'
-              value: number
-            }
-          ]
         },
         {
           attr: '退院'
@@ -37,8 +27,6 @@ type ConfirmedCasesType = {
   検査実施人数: number
   陽性物数: number
   入院中: number
-  軽症中等症: number
-  重症: number
   死亡: number
   退院: number
 }
@@ -53,8 +41,6 @@ export default (data: DataType) => {
     検査実施人数: data.value,
     陽性物数: data.children[0].value,
     入院中: data.children[0].children[0].value,
-    軽症中等症: data.children[0].children[0].children[0].value,
-    重症: data.children[0].children[0].children[1].value,
     死亡: data.children[0].children[2].value,
     退院: data.children[0].children[1].value
   }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #63 

## 📝 関連する issue / Related Issues
なし

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 長野県が公開するオープンデータに合わせてグラフから「軽症・中等症者」と「重症者」を削除

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
* PC
![image](https://user-images.githubusercontent.com/5682821/78459190-44673880-76f2-11ea-8f49-d8d1f3662f8a.png)

* SmartPhone
![image](https://user-images.githubusercontent.com/5682821/78459297-f43ca600-76f2-11ea-819c-f3cf532d6ad3.png)

