### PR TITLE
Maintain repository_dispatch triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: build check
 
 on:
   repository_dispatch:
+    types: [build_application]
   pull_request:
     branches:
       - staging

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,7 @@ name: production deploy
 
 on:
   repository_dispatch:
+    types: [build_application]
   push:
     branches:
       - master

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -2,6 +2,7 @@ name: development deploy
 
 on:
   repository_dispatch:
+    types: [build_application]
   push:
     branches:
       - development

--- a/.github/workflows/ogp_builder.yml
+++ b/.github/workflows/ogp_builder.yml
@@ -2,6 +2,7 @@ name: OGP Builder
 
 on:
   repository_dispatch:
+    types: [build_application]
   push:
     branches:
       - staging

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -2,7 +2,6 @@ name: screenshot
 
 # on: pull_request
 on:
-  repository_dispatch:
   push:
     branches:
       - dummy

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,6 +2,7 @@ name: staging deploy
 
 on:
   repository_dispatch:
+    types: [build_application]
   push:
     branches:
       - staging


### PR DESCRIPTION
- Taking advantages using 'types' to filter events
- Remove the trigger from the screenshot action as it's not necessary

- Close #28 

## 📝 関連する issue / Related Issues
- #28

## ⛏ 変更内容 / Details of Changes
Github Action のトリガー repository_dispatch に明示的にイベントタイプフィルターを追加。将来の自動化に役に立つかもです。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
